### PR TITLE
Encode location names

### DIFF
--- a/app/assets/scripts/components/location-card.js
+++ b/app/assets/scripts/components/location-card.js
@@ -40,7 +40,7 @@ var LocationCard = React.createClass({
         <div className='card__contents'>
           <header className='card__header'>
             <p className='card__subtitle'>Updated <strong>{updated}</strong></p>
-            <h1 className='card__title'><Link to={`/location/${this.props.name}`} title={`View ${this.props.name} page`}>{this.props.name}</Link> <small>in {this.props.city}, {this.props.countryData.name}</small></h1>
+            <h1 className='card__title'><Link to={`/location/${encodeURIComponent(this.props.name)}`} title={`View ${this.props.name} page`}>{this.props.name}</Link> <small>in {this.props.city}, {this.props.countryData.name}</small></h1>
           </header>
           <div className='card__body'>
             <ul className='card__meta-details'>
@@ -55,7 +55,7 @@ var LocationCard = React.createClass({
           <footer className='card__footer'>
             <ul className='card__actions'>
               <li><a href='#' className='button-card-download' title={`Download data for ${this.props.name}`} onClick={this.onDownloadClick}>Download</a></li>
-              <li><Link to={`/location/${this.props.name}`} className='button-card-view' title={`View ${this.props.name} page`}>View More</Link></li>
+              <li><Link to={`/location/${encodeURIComponent(this.props.name)}`} className='button-card-view' title={`View ${this.props.name} page`}>View More</Link></li>
             </ul>
           </footer>
         </div>

--- a/app/assets/scripts/components/map.js
+++ b/app/assets/scripts/components/map.js
@@ -467,7 +467,7 @@ const MapPopover = React.createClass({
       <article className='popover'>
         <div className='popover__contents'>
           <header className='popover__header'>
-            <h1 className='popover__title'><a href={`#/location/${this.props.location}`} title={`View ${this.props.location} page`}>{this.props.location}</a></h1>
+            <h1 className='popover__title'><a href={`#/location/${encodeURIComponent(this.props.location)}`} title={`View ${this.props.location} page`}>{this.props.location}</a></h1>
           </header>
           <div className='popover__body'>
             {reading}
@@ -476,8 +476,8 @@ const MapPopover = React.createClass({
                 Using `a` instead of `Link` because these are rendered outside
                 the router context and `Link` needs that context to work.
               */ }
-              <li><a href={`#/compare/${this.props.location}`} className='button button--primary-bounded' title={`Compare ${this.props.location} with other locations`}>Compare</a></li>
-              <li><a href={`#/location/${this.props.location}`} title={`View ${this.props.location} page`}className='button button--primary-bounded'>View More</a></li>
+              <li><a href={`#/compare/${encodeURIComponent(this.props.location)}`} className='button button--primary-bounded' title={`Compare ${this.props.location} with other locations`}>Compare</a></li>
+              <li><a href={`#/location/${encodeURIComponent(this.props.location)}`} title={`View ${this.props.location} page`}className='button button--primary-bounded'>View More</a></li>
             </ul>
           </div>
           <footer className='popover__footer'>

--- a/app/assets/scripts/components/share-btn.js
+++ b/app/assets/scripts/components/share-btn.js
@@ -17,8 +17,8 @@ var ShareBtn = React.createClass({
         triggerText='Share' >
 
         <ul role='menu' className='drop__menu drop__menu--select'>
-          <li><a className='drop__menu-item share-opt-twitter' href={`https://twitter.com/share?url=${encodeURIComponent(window.location.href)}`} target='_blank' title='Share on twitter' data-hook='dropdown:close'><span>Twitter</span></a></li>
-          <li><a className='drop__menu-item share-opt-facebook' href={`http://facebook.com/sharer.php?u=${encodeURIComponent(window.location.href)}`} target='_blank' title='Share on Facebook' data-hook='dropdown:close'><span>Facebook</span></a></li>
+          <li><a className='drop__menu-item share-opt-twitter' href={`https://twitter.com/share?url=${window.location.href}`} target='_blank' title='Share on twitter' data-hook='dropdown:close'><span>Twitter</span></a></li>
+          <li><a className='drop__menu-item share-opt-facebook' href={`http://facebook.com/sharer.php?u=${window.location.href}`} target='_blank' title='Share on Facebook' data-hook='dropdown:close'><span>Facebook</span></a></li>
         </ul>
       </Dropdown>
     );

--- a/app/assets/scripts/views/compare.js
+++ b/app/assets/scripts/views/compare.js
@@ -269,7 +269,7 @@ var Compare = React.createClass({
       return (
         <li className='compare__location' key={d.location}>
           <p className='compare__subtitle'>Updated {updated}</p>
-          <h2 className='compare__title'><Link to={`/location/${d.location}`}><span className={c('compare-marker', kl[i])}>{d.location}</span></Link> <small>in {d.city}, {countryData.name}</small></h2>
+          <h2 className='compare__title'><Link to={`/location/${encodeURIComponent(d.location)}`}><span className={c('compare-marker', kl[i])}>{d.location}</span></Link> <small>in {d.city}, {countryData.name}</small></h2>
           <div className='compare__actions'>
             { /* <button type='button' className='button button--small button--primary-unbounded'>Edit</button> */ }
             <button type='button' className='button button--small button--primary-unbounded' onClick={this.removeLocClick.bind(null, i)}>Remove</button>

--- a/app/assets/scripts/views/compare.js
+++ b/app/assets/scripts/views/compare.js
@@ -90,6 +90,7 @@ var Compare = React.createClass({
   onFilterSelect: function (parameter, e) {
     e.preventDefault();
     let locsUrl = this.getLocNames()
+      .map(encodeURIComponent)
       .join('/');
 
     hashHistory.push(`/compare/${locsUrl}?parameter=${parameter}`);
@@ -99,6 +100,7 @@ var Compare = React.createClass({
     // To build the url filter out the location at the given index.
     // Ensure that non loaded locations are also out.
     let locsUrl = this.getLocNames((o, i) => i !== index)
+      .map(encodeURIComponent)
       .join('/');
 
     hashHistory.push(`/compare/${locsUrl}?parameter=${this.getActiveParameterData().id}`);
@@ -126,7 +128,11 @@ var Compare = React.createClass({
     let locsUrl = this.getLocNames();
     locsUrl.push(this.props.compareSelectOpts.location);
 
-    hashHistory.push(`/compare/${locsUrl.join('/')}?parameter=${this.getActiveParameterData().id}`);
+    locsUrl = locsUrl
+      .map(encodeURIComponent)
+      .join('/');
+
+    hashHistory.push(`/compare/${locsUrl}?parameter=${this.getActiveParameterData().id}`);
   },
 
   //

--- a/app/assets/scripts/views/home.js
+++ b/app/assets/scripts/views/home.js
@@ -231,7 +231,7 @@ var Home = React.createClass({
                 return (
                   <li className='compare__location' key={d.location} >
                     <p className='compare__subtitle'>Updated {updated}</p>
-                    <h2 className='compare__title'><Link to={`/location/${d.location}`}><span className={c('compare-marker', kl[i])}>{d.location}</span></Link> <small>in {d.city}, {countryData.name}</small></h2>
+                    <h2 className='compare__title'><Link to={`/location/${encodeURIComponent(d.location)}`}><span className={c('compare-marker', kl[i])}>{d.location}</span></Link> <small>in {d.city}, {countryData.name}</small></h2>
                   </li>
                 );
               })}
@@ -257,7 +257,7 @@ var Home = React.createClass({
           {body}
           <div className='fold__footer'>
           {l1.data && l2.data
-          ? <Link to={`/compare/${l1.data.location}/${l2.data.location}`} title='View Locations' className='button button--large button--primary-bounded button--semi-fluid'>Compare Other Locations</Link>
+          ? <Link to={`/compare/${encodeURIComponent(l1.data.location)}/${encodeURIComponent(l2.data.location)}`} title='View Locations' className='button button--large button--primary-bounded button--semi-fluid'>Compare Other Locations</Link>
           : null}
           </div>
         </div>

--- a/app/assets/scripts/views/location.js
+++ b/app/assets/scripts/views/location.js
@@ -92,7 +92,7 @@ var Location = React.createClass({
   onFilterSelect: function (parameter, e) {
     e.preventDefault();
 
-    hashHistory.push(`/location/${this.props.params.name}?parameter=${parameter}`);
+    hashHistory.push(`/location/${encodeURIComponent(this.props.params.name)}?parameter=${parameter}`);
   },
 
   onDownloadClick: function () {
@@ -499,7 +499,7 @@ var Location = React.createClass({
               <ul>
                 <li><a href={`${config.api}/locations?location=${data.location}`} title='View in api' className='button-inpage-api' target='_blank'>View API</a></li>
                 <li><button type='button' title='Download data for this location' className='button-inpage-download' onClick={this.onDownloadClick}>Download</button></li>
-                <li><Link to={`/compare/${data.location}`} title='Compare location with another' className='button button--primary button--medium'>Compare</Link></li>
+                <li><Link to={`/compare/${encodeURIComponent(data.location)}`} title='Compare location with another' className='button button--primary button--medium'>Compare</Link></li>
               </ul>
             </div>
           </div>


### PR DESCRIPTION
Fix #122 

Quite interesting behavior this one. Firefox automatically encodes the url when you copy it, but chrome doesn't. I used `encodeURIComponent` to solve this.

On firefox the url will still be shown with spaces but when you copy it will be encoded. i.e. the spaces will be repalced with `%20`. On chrome the url will be encoded in the url bar from the start.

Could you see if it behaves as expected? @jflasher @RocketD0g 